### PR TITLE
Update version to 18.5.1 and enhance character sheet layout support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Pelilauta",
   "type": "module",
-  "version": "18.5.0",
+  "version": "18.5.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/src/components/svelte/characters/CharacterApp/StatBlockView.svelte
+++ b/src/components/svelte/characters/CharacterApp/StatBlockView.svelte
@@ -4,14 +4,16 @@ import { t } from '@utils/i18n';
 import Stat from './Stat.svelte';
 
 interface Props {
-  group: string;
+  group: { key: string; layout: string };
 }
 
 const { group }: Props = $props();
 
 const statsInGroup = $derived.by(() => {
   if (!$resolvedCharacter?.sheet?.stats) return [];
-  return $resolvedCharacter.sheet.stats.filter((stat) => stat.group === group);
+  return $resolvedCharacter.sheet.stats.filter(
+    (stat) => stat.group === group.key,
+  );
 });
 
 const type = (key: string) => {
@@ -22,7 +24,7 @@ const type = (key: string) => {
 };
 </script>
 
-<cn-stat-block label={group}>
+<cn-stat-block label={group.key} layout={group.layout}>
   {#each statsInGroup as stat}
     {#if stat.type === 'number'}
       <div class="flex flex-row flex-no-wrap">
@@ -30,6 +32,22 @@ const type = (key: string) => {
           {stat.key}
         </h4>
         <input type="number" value={stat.value} class="stat flex-none" style="flex:none" readonly />
+      </div>
+    {:else if stat.type === 'd20_ability_score'}
+      <cn-d20-ability-score
+        class="stat"
+        value={stat.value}
+        label={stat.key}
+        readonly
+      ></cn-d20-ability-score>
+    {:else if stat.type === 'toggled'}
+      <div class="flex items-center">
+        <h4 class="text-h5 m-0 grow" style="flex-grow:1">
+          {stat.key}
+        </h4>
+        <div>
+          <input type="checkbox" class="stat" checked={stat.value === true} readonly />
+        </div>
       </div>
     {/if}
   {/each}

--- a/src/docs/80-release-notes.md
+++ b/src/docs/80-release-notes.md
@@ -5,6 +5,10 @@ noun: 'monsters'
 ---
 ## Version 18
 
+### 18.5.x (ongoing)
+- fix(characters): Character sheets support layout settings for stat groups
+- fix(characters): Character sheet stat blocks are rendered correctly for toggled, number, and d20_ability_score stat types. Note: Cyan Design System 4 does not yet have full support for checkbox/toggled stat input, which will cause some visual inconsistencies.
+
 ### 18.5.0 (19.9.2025)
 - feat(characters): Character sheet schema supports layout settings for stat groups
 


### PR DESCRIPTION
Update the version to 18.5.1 and improve the character sheet layout by adding support for different stat types, including toggled and d20 ability scores. Does not adress visual inconsistencies within the design system.